### PR TITLE
Add dropRepository task

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The plugin provides three main tasks:
  - `closeRepository` - closes open repository with uploaded artifacts. There should be just one open repository available in the staging profile
 (possible old/broken repositories can be dropped with Nexus GUI)
  - `promoteRepository` - promotes/releases closed repository (required to put artifacts to Maven Central)
+ - `dropRepository` - drops promoted repository
  - `closeAndPromoteRepository` - closes and promotes/releases repository (an equivalent to `closeRepository promoteRepository`)
  
 And one additional:

--- a/src/main/groovy/io/codearte/gradle/nexus/BaseStagingTask.groovy
+++ b/src/main/groovy/io/codearte/gradle/nexus/BaseStagingTask.groovy
@@ -6,6 +6,7 @@ import groovyx.net.http.RESTClient
 import io.codearte.gradle.nexus.infra.SimplifiedHttpJsonRestClient
 import io.codearte.gradle.nexus.logic.OperationRetrier
 import io.codearte.gradle.nexus.logic.RepositoryCloser
+import io.codearte.gradle.nexus.logic.RepositoryDropper
 import io.codearte.gradle.nexus.logic.RepositoryFetcher
 import io.codearte.gradle.nexus.logic.RepositoryPromoter
 import io.codearte.gradle.nexus.logic.StagingProfileFetcher
@@ -61,6 +62,10 @@ abstract class BaseStagingTask extends DefaultTask {
 
     protected RepositoryPromoter createRepositoryPromoterWithGivenClient(SimplifiedHttpJsonRestClient client) {
         return new RepositoryPromoter(client, getServerUrl())
+    }
+
+    protected RepositoryDropper createRepositoryDropperWithGivenClient(SimplifiedHttpJsonRestClient client) {
+        return new RepositoryDropper(client, getServerUrl())
     }
 
     protected <T> OperationRetrier<T> createOperationRetrier() {

--- a/src/main/groovy/io/codearte/gradle/nexus/DropRepositoryTask.groovy
+++ b/src/main/groovy/io/codearte/gradle/nexus/DropRepositoryTask.groovy
@@ -1,0 +1,36 @@
+package io.codearte.gradle.nexus
+
+import groovy.transform.CompileStatic
+import io.codearte.gradle.nexus.logic.OperationRetrier
+import io.codearte.gradle.nexus.logic.RepositoryDropper
+import io.codearte.gradle.nexus.logic.RepositoryFetcher
+import io.codearte.gradle.nexus.logic.StagingProfileFetcher
+import org.gradle.api.tasks.TaskAction
+
+@CompileStatic
+public class DropRepositoryTask extends BaseStagingTask {
+
+    @TaskAction
+    void doAction() {
+        StagingProfileFetcher stagingProfileFetcher = createFetcherWithGivenClient(createClient())
+        RepositoryFetcher repositoryFetcher = createRepositoryFetcherWithGivenClient(createClient())
+        RepositoryDropper repositoryDropper = createRepositoryDropperWithGivenClient(createClient())
+        OperationRetrier<String> retrier = createOperationRetrier()
+
+        tryToTakeStagingProfileIdFromPromoteRepositoryTask()
+        String stagingProfileId = fetchAndCacheStagingProfileId(stagingProfileFetcher)
+        String repositoryId = retrier.doWithRetry { repositoryFetcher.getPromotedRepositoryIdForStagingProfileId(stagingProfileId) }
+        repositoryDropper.dropRepositoryWithIdAndStagingProfileId(repositoryId, stagingProfileId)
+    }
+
+    private void tryToTakeStagingProfileIdFromPromoteRepositoryTask() {
+        if (getStagingProfileId() != null) {
+            return
+        }
+        String stagingProfileIdFromPromoteRepositoryTask = project.tasks.withType(PromoteRepositoryTask)[0].getStagingProfileId()
+        if (stagingProfileIdFromPromoteRepositoryTask != null) {
+            logger.debug("Reusing staging profile id from promoteRepository task: $stagingProfileIdFromPromoteRepositoryTask")
+            setStagingProfileId(stagingProfileIdFromPromoteRepositoryTask)
+        }
+    }
+}

--- a/src/main/groovy/io/codearte/gradle/nexus/NexusStagingPlugin.groovy
+++ b/src/main/groovy/io/codearte/gradle/nexus/NexusStagingPlugin.groovy
@@ -20,6 +20,7 @@ class NexusStagingPlugin implements Plugin<Project> {
     private static final String GET_STAGING_PROFILE_TASK_NAME = "getStagingProfile"
     private static final String CLOSE_REPOSITORY_TASK_NAME = "closeRepository"
     private static final String PROMOTE_REPOSITORY_TASK_NAME = "promoteRepository"
+    private static final String DROP_REPOSITORY_TASK_NAME = "dropRepository"
     private static final String CLOSE_AND_PROMOTE_REPOSITORY_TASK_NAME = "closeAndPromoteRepository"
 
     private static final Set<Class> STAGING_TASK_CLASSES = [GetStagingProfileTask, CloseRepositoryTask, PromoteRepositoryTask]
@@ -38,7 +39,9 @@ class NexusStagingPlugin implements Plugin<Project> {
         createAndConfigureGetStagingProfileTask(project)
         def closeRepositoryTask = createAndConfigureCloseRepositoryTask(project)
         def promoteRepositoryTask = createAndConfigurePromoteRepositoryTask(project)
+        def dropRepositoryTask = createAndConfigureDropRepositoryTask(project)
         promoteRepositoryTask.mustRunAfter(closeRepositoryTask)
+        dropRepositoryTask.mustRunAfter(promoteRepositoryTask)
         def closeAndPromoteRepositoryTask = createAndConfigureCloseAndPromoteRepositoryTask(project)
         closeAndPromoteRepositoryTask.dependsOn(closeRepositoryTask, promoteRepositoryTask)
         tryToDetermineCredentials(project, extension)
@@ -76,6 +79,13 @@ class NexusStagingPlugin implements Plugin<Project> {
     private PromoteRepositoryTask createAndConfigurePromoteRepositoryTask(Project project) {
         PromoteRepositoryTask task = project.tasks.create(PROMOTE_REPOSITORY_TASK_NAME, PromoteRepositoryTask)
         setTaskDescriptionAndGroup(task, "Promotes/releases a closed artifacts repository in Nexus")
+        setTaskDefaultsAndDescription(task)
+        return task
+    }
+
+    private DropRepositoryTask createAndConfigureDropRepositoryTask(Project project) {
+        DropRepositoryTask task = project.tasks.create(DROP_REPOSITORY_TASK_NAME, DropRepositoryTask)
+        setTaskDescriptionAndGroup(task, "Drops a promoted artifacts repository in Nexus")
         setTaskDefaultsAndDescription(task)
         return task
     }

--- a/src/main/groovy/io/codearte/gradle/nexus/logic/RepositoryFetcher.groovy
+++ b/src/main/groovy/io/codearte/gradle/nexus/logic/RepositoryFetcher.groovy
@@ -16,6 +16,10 @@ class RepositoryFetcher extends BaseOperationExecutor {
         return getRepositoryIdWithGivenStateForStagingProfileId("closed", stagingProfileId)
     }
 
+    String getPromotedRepositoryIdForStagingProfileId(String stagingProfileId) {
+        return getRepositoryIdWithGivenStateForStagingProfileId("promoted", stagingProfileId)
+    }
+
     private String getRepositoryIdWithGivenStateForStagingProfileId(String state, String stagingProfileId) {
         log.info("Getting '$state' repository for staging profile '$stagingProfileId'")
         Map responseAsMap = client.get(nexusUrl + "/staging/profile_repositories/$stagingProfileId")    //TODO: Constant

--- a/src/main/groovy/io/codearte/gradle/nexus/logic/RepositroyDropper.groovy
+++ b/src/main/groovy/io/codearte/gradle/nexus/logic/RepositroyDropper.groovy
@@ -1,0 +1,19 @@
+package io.codearte.gradle.nexus.logic
+
+import groovy.transform.CompileStatic
+import groovy.transform.InheritConstructors
+import groovy.util.logging.Slf4j;
+
+@CompileStatic
+@InheritConstructors
+@Slf4j
+class RepositoryDropper extends AbstractStagingOperationExecutor {
+
+    void dropRepositoryWithIdAndStagingProfileId(String repositoryId, String stagingProfileId) {
+        log.info("Dropping repository '$repositoryId' with staging profile '$stagingProfileId'")
+        Map postContent = prepareStagingPostContentWithGivenRepositoryIdAndStagingId(repositoryId, stagingProfileId)
+        client.post(nexusUrl + "/staging/profiles/$stagingProfileId/drop", postContent)
+        log.info("Repository '$repositoryId' with staging profile '$stagingProfileId' has been dropped")
+    }
+}
+

--- a/src/test/groovy/io/codearte/gradle/nexus/functional/BasicFunctionalSpec.groovy
+++ b/src/test/groovy/io/codearte/gradle/nexus/functional/BasicFunctionalSpec.groovy
@@ -56,4 +56,19 @@ class BasicFunctionalSpec extends BaseNexusStagingFunctionalSpec {
         and:
             result.standardOutput.contains("has been promotted")   //TODO: Match with regexp
     }
+
+    @Ignore
+    def "should drop promoted repository"() {
+        given:
+            buildFile << """
+                ${getApplyPluginBlock()}
+                ${getDefaultConfigurationClosure()}
+            """.stripIndent()
+        when:
+            def result = runTasksSuccessfully('dropRepository')
+        then:
+            result.wasExecuted(':dropRepository')
+        and:
+            result.standardOutput.contains("has been dropped")   //TODO: Match with regexp
+    }
 }

--- a/src/test/groovy/io/codearte/gradle/nexus/logic/RepositoryDropperSpec.groovy
+++ b/src/test/groovy/io/codearte/gradle/nexus/logic/RepositoryDropperSpec.groovy
@@ -1,0 +1,36 @@
+package io.codearte.gradle.nexus.logic
+
+import groovy.json.JsonSlurper
+import groovyx.net.http.RESTClient
+import io.codearte.gradle.nexus.PasswordUtil
+import io.codearte.gradle.nexus.infra.SimplifiedHttpJsonRestClient
+import spock.lang.Ignore
+
+class RepositoryDropperSpec extends BaseOperationExecutorSpec {
+
+    private static final String DROP_REPOSITORY_PATH = "/staging/profiles/$TEST_STAGING_PROFILE_ID/drop"
+    private static final String DROP_REPOSITORY_FULL_URL = MOCK_SERVER_HOST + DROP_REPOSITORY_PATH
+
+    @Ignore
+    def "should drop repository e2e"() {
+        given:
+            def client = new SimplifiedHttpJsonRestClient(new RESTClient(), "codearte", PasswordUtil.tryToReadNexusPassword())
+            def dropper = new RepositoryDropper(client, E2E_TEST_SERVER_BASE_PATH)
+        when:
+            dropper.dropRepositoryWithIdAndStagingProfileId(TEST_REPOSITORY_ID, TEST_STAGING_PROFILE_ID)
+        then:
+            noExceptionThrown()
+    }
+
+    def "should drop repository"() {
+        given:
+            def client = Mock(SimplifiedHttpJsonRestClient)
+            def dropper = new RepositoryDropper(client, MOCK_SERVER_HOST)
+        when:
+            dropper.dropRepositoryWithIdAndStagingProfileId(TEST_REPOSITORY_ID, TEST_STAGING_PROFILE_ID)
+        then:
+            1 * client.post(DROP_REPOSITORY_FULL_URL, _) >> { uri, content ->
+                assert content == new JsonSlurper().parse(this.getClass().getResource("commonStagingRepositoryRequest.json"))
+            }
+    }
+}

--- a/src/test/groovy/io/codearte/gradle/nexus/logic/RepositoryPromoterSpec.groovy
+++ b/src/test/groovy/io/codearte/gradle/nexus/logic/RepositoryPromoterSpec.groovy
@@ -15,9 +15,9 @@ class RepositoryPromoterSpec extends BaseOperationExecutorSpec {
     def "should promote repository e2e"() {
         given:
             def client = new SimplifiedHttpJsonRestClient(new RESTClient(), "codearte", PasswordUtil.tryToReadNexusPassword())
-            def closer = new RepositoryPromoter(client, E2E_TEST_SERVER_BASE_PATH)
+            def promoter = new RepositoryPromoter(client, E2E_TEST_SERVER_BASE_PATH)
         when:
-            closer.promoteRepositoryWithIdAndStagingProfileId(TEST_REPOSITORY_ID, TEST_STAGING_PROFILE_ID)
+            promoter.promoteRepositoryWithIdAndStagingProfileId(TEST_REPOSITORY_ID, TEST_STAGING_PROFILE_ID)
         then:
             noExceptionThrown()
     }
@@ -25,9 +25,9 @@ class RepositoryPromoterSpec extends BaseOperationExecutorSpec {
     def "should promote repository"() {
         given:
             def client = Mock(SimplifiedHttpJsonRestClient)
-            def closer = new RepositoryPromoter(client, MOCK_SERVER_HOST)
+            def promoter = new RepositoryPromoter(client, MOCK_SERVER_HOST)
         when:
-            closer.promoteRepositoryWithIdAndStagingProfileId(TEST_REPOSITORY_ID, TEST_STAGING_PROFILE_ID)
+            promoter.promoteRepositoryWithIdAndStagingProfileId(TEST_REPOSITORY_ID, TEST_STAGING_PROFILE_ID)
         then:
             1 * client.post(PROMOTE_REPOSITORY_FULL_URL, _) >> { uri, content ->
                 assert content == new JsonSlurper().parse(this.getClass().getResource("commonStagingRepositoryRequest.json"))


### PR DESCRIPTION
I am currently using this plugin to release multiple modules that are part of a single project. After each module is promoted it takes around 10 minutes for the promoted repository to be dropped. Since it's only possible to have one repository present at a time I have to wait 10 minutes after each module is promoted before uploading, closing and promoting the next one.

This PR adds support for dropping a repository that is in the 'promoted' state and eliminating the need to wait for a repository to be automatically dropped.

Unfortunately I ran into some troubles with nebula-test and was unable to attach a debugger to resolve why the two new tests in `MockedFunctionalSpec` are failing. "should retry drop when repository has not been already promoted" is failing because a string starting with `<html>` is being returned to `SimplifiedHttpJsonRestClient#get` for an unknown reason and "should reuse stagingProfileId from promoteRepository in dropRepository when called together" is failing because the repository is in the wrong state which seems like the tasks are not running in the correct order. If there are any suggestions, I'm happy to take a further look at these tests.
