### PR TITLE
add error information for when sonatype fails

### DIFF
--- a/src/main/groovy/io/codearte/gradle/nexus/infra/SimplifiedHttpJsonRestClient.groovy
+++ b/src/main/groovy/io/codearte/gradle/nexus/infra/SimplifiedHttpJsonRestClient.groovy
@@ -63,6 +63,7 @@ class SimplifiedHttpJsonRestClient {
 		
 			HttpResponseDecorator resp = e.getResponse();
 			String message = "${resp.statusLine.statusCode}:${resp.statusLine.reasonPhrase}  body=${resp.data}"
+		    log.error("POST response failed.  ${message}")
 			throw new HttpResponseException(e.getStatusCode(), message)
 		}
     }


### PR DESCRIPTION
This adds the info so e.getMessage() when used which is printed when using --stacktrace.  Also, we log the same thing as well for those not using --stacktrace as this is a pretty important failure and one needs to know the issue that occurred from the remote end.