### PR TITLE
Adding configurable staging repository description

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
 language: groovy
 
 before_install:
-  # Encrypted key is not available in PR
+  # Secrets (including enncrypted PGP key) are not available in PR - skip release configuration to do not fail build
   - |
     if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then 
       openssl aes-256-cbc -K $encrypted_21cd6bba12a0_key -iv $encrypted_21cd6bba12a0_iv -in gradle/gpg-key.asc.enc -d | gpg --fast-import
+      # Environment variables cannot have "." and it's problematic to pass them with "ORG_GRADLE_PROJECT_"
+      # In addition GRADLE_OPTS doesn't seem to be passed to Gradle started with Nebula (for AT/E2E tests)
       mkdir -p ~/.gradle
       echo "signing.keyIdAT=0694F057" >> ~/.gradle/gradle.properties
       echo "signing.secretKeyRingFileAT=$HOME/.gnupg/secring.gpg" >> ~/.gradle/gradle.properties
       echo "signing.passwordAT=" >> ~/.gradle/gradle.properties
+      # Enable E2E tests if desired in given build variant and not in PR - #56
+      # Setting environment variables in "env" seems to be too primite to support it inline
       if [ "$NEXUS_AT_ENABLE_E2E_TESTS_IN_VARIANT" == "true" ]; then export NEXUS_AT_ENABLE_E2E_TESTS=true; fi;
+      # regular releasing (not AT/E2E)
       export GRADLE_OPTS='-Dorg.gradle.project.signing.keyId=0694F057 -Dorg.gradle.project.signing.secretKeyRingFile=$HOME/.gnupg/secring.gpg -Dorg.gradle.project.signing.password= -Dorg.gradle.project.gradle.publish.key=$PLUGIN_PORTAL_API_KEY -Dorg.gradle.project.gradle.publish.secret=$PLUGIN_PORTAL_API_SECRET'
     fi;
   - "export TRAVIS_COMMIT_MSG=$(git log --format=%B -n 1 $TRAVIS_COMMIT)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ language: groovy
 before_install:
   # Secrets (including enncrypted PGP key) are not available in PR - skip release configuration to do not fail build
   - |
-    if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then 
-      openssl aes-256-cbc -K $encrypted_21cd6bba12a0_key -iv $encrypted_21cd6bba12a0_iv -in gradle/gpg-key.asc.enc -d | gpg --fast-import
+    if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
+     # There is problem with aborting build on command in if failure - http://steven.casagrande.io/articles/travis-ci-and-if-statements/
+     openssl aes-256-cbc -K $encrypted_21cd6bba12a0_key -iv $encrypted_21cd6bba12a0_iv -in gradle/gpg-key.asc.enc -d | gpg --fast-import || travis_terminate 1
       # Environment variables cannot have "." and it's problematic to pass them with "ORG_GRADLE_PROJECT_"
       # In addition GRADLE_OPTS doesn't seem to be passed to Gradle started with Nebula (for AT/E2E tests)
       mkdir -p ~/.gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: groovy
 
 before_install:
-  - openssl aes-256-cbc -K $encrypted_21cd6bba12a0_key -iv $encrypted_21cd6bba12a0_iv
-    -in gradle/gpg-key.asc.enc -d | gpg --fast-import
+  # Encrypted key is not available in PR
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then openssl aes-256-cbc -K $encrypted_21cd6bba12a0_key -iv $encrypted_21cd6bba12a0_iv -in gradle/gpg-key.asc.enc -d | gpg --fast-import; fi;
   # Environment variables cannot have "." and it's problematic to pass them with "ORG_GRADLE_PROJECT_"
   # In addition GRADLE_OPTS doesn't seem to be passed to Gradle started with Nebula (for AT/E2E tests)
   - mkdir -p ~/.gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,20 @@ language: groovy
 
 before_install:
   # Encrypted key is not available in PR
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then openssl aes-256-cbc -K $encrypted_21cd6bba12a0_key -iv $encrypted_21cd6bba12a0_iv -in gradle/gpg-key.asc.enc -d | gpg --fast-import; fi;
-  # Environment variables cannot have "." and it's problematic to pass them with "ORG_GRADLE_PROJECT_"
-  # In addition GRADLE_OPTS doesn't seem to be passed to Gradle started with Nebula (for AT/E2E tests)
-  - mkdir -p ~/.gradle
-  - echo "signing.keyIdAT=0694F057" >> ~/.gradle/gradle.properties
-  - echo "signing.secretKeyRingFileAT=$HOME/.gnupg/secring.gpg" >> ~/.gradle/gradle.properties
-  - echo "signing.passwordAT=" >> ~/.gradle/gradle.properties
-  # Enable E2E tests if desired in given build variant and not in PR - #56
-  # Setting environment variables in "env" seems to be too primite to support it inline
-  - if [ "$NEXUS_AT_ENABLE_E2E_TESTS_IN_VARIANT" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then export NEXUS_AT_ENABLE_E2E_TESTS=true; fi;
-  # regular releasing (not AT/E2E)
-  - "export GRADLE_OPTS='-Dorg.gradle.project.signing.keyId=0694F057 -Dorg.gradle.project.signing.secretKeyRingFile=$HOME/.gnupg/secring.gpg -Dorg.gradle.project.signing.password= -Dorg.gradle.project.gradle.publish.key=$PLUGIN_PORTAL_API_KEY -Dorg.gradle.project.gradle.publish.secret=$PLUGIN_PORTAL_API_SECRET'"
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then 
+      openssl aes-256-cbc -K $encrypted_21cd6bba12a0_key -iv $encrypted_21cd6bba12a0_iv -in gradle/gpg-key.asc.enc -d | gpg --fast-import; 
+      # Environment variables cannot have "." and it's problematic to pass them with "ORG_GRADLE_PROJECT_"
+      # In addition GRADLE_OPTS doesn't seem to be passed to Gradle started with Nebula (for AT/E2E tests)
+      mkdir -p ~/.gradle;
+      echo "signing.keyIdAT=0694F057" >> ~/.gradle/gradle.properties;
+      echo "signing.secretKeyRingFileAT=$HOME/.gnupg/secring.gpg" >> ~/.gradle/gradle.properties;
+      echo "signing.passwordAT=" >> ~/.gradle/gradle.properties;
+      # Enable E2E tests if desired in given build variant and not in PR - #56
+      # Setting environment variables in "env" seems to be too primite to support it inline
+      if [ "$NEXUS_AT_ENABLE_E2E_TESTS_IN_VARIANT" == "true" ]; then export NEXUS_AT_ENABLE_E2E_TESTS=true; fi;
+      # regular releasing (not AT/E2E)
+      export GRADLE_OPTS='-Dorg.gradle.project.signing.keyId=0694F057 -Dorg.gradle.project.signing.secretKeyRingFile=$HOME/.gnupg/secring.gpg -Dorg.gradle.project.signing.password= -Dorg.gradle.project.gradle.publish.key=$PLUGIN_PORTAL_API_KEY -Dorg.gradle.project.gradle.publish.secret=$PLUGIN_PORTAL_API_SECRET'
+    fi;
   - "export TRAVIS_COMMIT_MSG=$(git log --format=%B -n 1 $TRAVIS_COMMIT)"
   - git config user.email "oss@codearte.io"
   - git config user.name "Codearte Continuous Delivery Bot"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,12 @@ before_install:
   # Encrypted key is not available in PR
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then 
       openssl aes-256-cbc -K $encrypted_21cd6bba12a0_key -iv $encrypted_21cd6bba12a0_iv -in gradle/gpg-key.asc.enc -d | gpg --fast-import; 
-      # Environment variables cannot have "." and it's problematic to pass them with "ORG_GRADLE_PROJECT_"
-      # In addition GRADLE_OPTS doesn't seem to be passed to Gradle started with Nebula (for AT/E2E tests)
       mkdir -p ~/.gradle;
       echo "signing.keyIdAT=0694F057" >> ~/.gradle/gradle.properties;
       echo "signing.secretKeyRingFileAT=$HOME/.gnupg/secring.gpg" >> ~/.gradle/gradle.properties;
       echo "signing.passwordAT=" >> ~/.gradle/gradle.properties;
-      # Enable E2E tests if desired in given build variant and not in PR - #56
-      # Setting environment variables in "env" seems to be too primite to support it inline
       if [ "$NEXUS_AT_ENABLE_E2E_TESTS_IN_VARIANT" == "true" ]; then export NEXUS_AT_ENABLE_E2E_TESTS=true; fi;
-      # regular releasing (not AT/E2E)
-      export GRADLE_OPTS='-Dorg.gradle.project.signing.keyId=0694F057 -Dorg.gradle.project.signing.secretKeyRingFile=$HOME/.gnupg/secring.gpg -Dorg.gradle.project.signing.password= -Dorg.gradle.project.gradle.publish.key=$PLUGIN_PORTAL_API_KEY -Dorg.gradle.project.gradle.publish.secret=$PLUGIN_PORTAL_API_SECRET'
+      export GRADLE_OPTS='-Dorg.gradle.project.signing.keyId=0694F057 -Dorg.gradle.project.signing.secretKeyRingFile=$HOME/.gnupg/secring.gpg -Dorg.gradle.project.signing.password= -Dorg.gradle.project.gradle.publish.key=$PLUGIN_PORTAL_API_KEY -Dorg.gradle.project.gradle.publish.secret=$PLUGIN_PORTAL_API_SECRET';
     fi;
   - "export TRAVIS_COMMIT_MSG=$(git log --format=%B -n 1 $TRAVIS_COMMIT)"
   - git config user.email "oss@codearte.io"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,15 @@ language: groovy
 
 before_install:
   # Encrypted key is not available in PR
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then 
-      openssl aes-256-cbc -K $encrypted_21cd6bba12a0_key -iv $encrypted_21cd6bba12a0_iv -in gradle/gpg-key.asc.enc -d | gpg --fast-import; 
-      mkdir -p ~/.gradle;
-      echo "signing.keyIdAT=0694F057" >> ~/.gradle/gradle.properties;
-      echo "signing.secretKeyRingFileAT=$HOME/.gnupg/secring.gpg" >> ~/.gradle/gradle.properties;
-      echo "signing.passwordAT=" >> ~/.gradle/gradle.properties;
+  - |
+    if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then 
+      openssl aes-256-cbc -K $encrypted_21cd6bba12a0_key -iv $encrypted_21cd6bba12a0_iv -in gradle/gpg-key.asc.enc -d | gpg --fast-import
+      mkdir -p ~/.gradle
+      echo "signing.keyIdAT=0694F057" >> ~/.gradle/gradle.properties
+      echo "signing.secretKeyRingFileAT=$HOME/.gnupg/secring.gpg" >> ~/.gradle/gradle.properties
+      echo "signing.passwordAT=" >> ~/.gradle/gradle.properties
       if [ "$NEXUS_AT_ENABLE_E2E_TESTS_IN_VARIANT" == "true" ]; then export NEXUS_AT_ENABLE_E2E_TESTS=true; fi;
-      export GRADLE_OPTS='-Dorg.gradle.project.signing.keyId=0694F057 -Dorg.gradle.project.signing.secretKeyRingFile=$HOME/.gnupg/secring.gpg -Dorg.gradle.project.signing.password= -Dorg.gradle.project.gradle.publish.key=$PLUGIN_PORTAL_API_KEY -Dorg.gradle.project.gradle.publish.secret=$PLUGIN_PORTAL_API_SECRET';
+      export GRADLE_OPTS='-Dorg.gradle.project.signing.keyId=0694F057 -Dorg.gradle.project.signing.secretKeyRingFile=$HOME/.gnupg/secring.gpg -Dorg.gradle.project.signing.password= -Dorg.gradle.project.gradle.publish.key=$PLUGIN_PORTAL_API_KEY -Dorg.gradle.project.gradle.publish.secret=$PLUGIN_PORTAL_API_SECRET'
     fi;
   - "export TRAVIS_COMMIT_MSG=$(git log --format=%B -n 1 $TRAVIS_COMMIT)"
   - git config user.email "oss@codearte.io"


### PR DESCRIPTION
my company relies on staging repository description for various cleanup jobs, so blindly setting them to "Automatically released/promoted with gradle-nexus-staging-plugin!" isn't always ideal.

I didn't add any tests because I couldn't figure out how to test this with wiremock - the best I could do was verify that the RepositoryCloser instance had the right description set in its field (which seemed kind of weak), so I didn't include that in this PR.  Suggestions are welcome.